### PR TITLE
Fix 'removeusertoken'

### DIFF
--- a/src/cmds/remove_user_token.py
+++ b/src/cmds/remove_user_token.py
@@ -20,7 +20,7 @@ async def perform_action(ctx: ApplicationContext, reply, user_id):
         await reply(ctx, 'Error: malformed user ID.')
         return
 
-    remove_record('DELETE FROM token WHERE user = %s or htbuser = %s', (user_id, user_id))
+    remove_record('DELETE FROM htb_discord_link WHERE user = %s or htbuser = %s', (user_id, user_id))
     await reply(ctx, f'All tokens related to Discord and HTB ID {user_id} have been deleted.')
 
 


### PR DESCRIPTION
'token' is the name of the old table - we use `htb_discord_link` in the current DB